### PR TITLE
헤더에 해시태그 메뉴 추가하기

### DIFF
--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -42,7 +42,8 @@
         <div class="container">
             <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
                 <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                    <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
+                    <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                    <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtags</a></li>
                 </ul>
 
                 <div class="text-end">

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+  <attr sel="#home" th:href="@{/}"/>
+  <attr sel="#hashtag" th:href="@{/articles/search-hashtag}"/>
+</thlogic>


### PR DESCRIPTION
이를 통해 검색을 용이하게 해줄 수 있음

헤더파일을 타임리프 파일과의 분리를 진행
헤드파일에 css를 따로 집어넣어줄 수 있는지 찾아보기

This closes #45 