### PR TITLE
헤로쿠 DB 변경 ClearDB -> JawsDB

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,7 +47,8 @@ spring:
       on-profile: heroku
 
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
`5.6`버전에서는 index 사이즈의 크기가 작음 'article_comment.content'
clearDB 버전이 5.6으로 mysql8버전과 충돌이 발생한다.

* https://devcenter.heroku.com/articles/jawsdb#provisioning-with-custom-options
* https://devcenter.heroku.com/articles/cleardb#the-cleardb-dedicated-mysql-complete-tutorial-local-setup