### PR TITLE
엔티티 코드 리팩토링 - equals(), hashcode()에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/src/main/java/com/example/boardproject/domain/Article.java
+++ b/src/main/java/com/example/boardproject/domain/Article.java
@@ -19,6 +19,7 @@ import java.util.Set;
 })
 @Entity
 public class Article extends AuditingFields {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -65,13 +66,12 @@ public class Article extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         // Pattern Matching for instanceof in Java 14
-        if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return this.getId() != null && this.getId().equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
-
 }

--- a/src/main/java/com/example/boardproject/domain/ArticleComment.java
+++ b/src/main/java/com/example/boardproject/domain/ArticleComment.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 })
 @Entity
 public class ArticleComment extends AuditingFields {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -49,12 +50,12 @@ public class ArticleComment extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof ArticleComment articleComment)) return false;
-        return id != null && id.equals(articleComment.id);
+        if (!(o instanceof ArticleComment that)) return false;
+        return this.getId() != null && this.getId().equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/example/boardproject/domain/User.java
+++ b/src/main/java/com/example/boardproject/domain/User.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 })
 @Entity
 public class User extends AuditingFields {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -55,12 +56,12 @@ public class User extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof User user)) return false;
-        return id != null && id.equals(user.id);
+        if (!(o instanceof User that)) return false;
+        return this.getId() != null && this.getId().equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }


### PR DESCRIPTION
여기서 필드에 직접 접근하면,
하이버네이트가 지연 로딩하려고 만든 프록시 객체를 다룰 때
필드 값이 `null`일 수 있음
그러면 제대로 비교 로직을 수행할 수 없기 떄문에
getter를 이용함.
이것으로 프록시 객체를 타더라도 제대로 값을 읽어올 수 있음
