### PR TITLE
[Feature] - swagger 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,11 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
+    implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.12'
+    annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0'
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
 


### PR DESCRIPTION
간단한 의존성 추가만으로 즉시 스웨거 문서화가 진행됨
이 때 Spring Data Rest 가 자동으로 만들어 준 api를
스웨거에 노출시키기 위해 추가 의존성을 사용함

This closes #90 